### PR TITLE
Remove .aid-see

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,15 +21,6 @@
 <a href="#main" class="aid-tab">skip</a>
 ```
 
-### `.aid-see`
-- accessible background-image replacement technique
-- useful for providing alternative text to background images or sprites
-- uses `transparent` technique that affords text selection
-
-```html
-<a href="#edit" class="aid-see sprite sprite-edit">edit</a>
-```
-
 ## aria
 
 Favor `aria-label` [where supported](https://www.w3.org/TR/using-aria/#label-support) because it works without needing extra tags or CSS.

--- a/aid.css
+++ b/aid.css
@@ -1,10 +1,3 @@
-.aid-see:link,
-.aid-see {
-  color: transparent;
-  text-shadow: none;
-  overflow: hidden;
-}
-
 .aid-tab:not(:focus),
 .aid-say {
   border: 0;

--- a/index.html
+++ b/index.html
@@ -25,9 +25,3 @@
   <figure class="block flow-compact"><code>&lt;a href="#demo" class="aid-tab"&gt;voice only unless focused&lt;/a&gt;</code></figure>
   <figure class="block flow-compact"><a href="#demo" class="aid-tab">voice only unless focused</a></figure>
 </figure>
-
-<figure class="block flow pad bg-white">
-  <figcaption class="block flow-compact"><code class="bold family">.aid-see</code></figcaption>
-  <figure class="block flow-compact"><code>&lt;a href="#demo" class="aid-see block bg-black"&gt;voice alternative for background images&lt;/a&gt;</code></figure>
-  <figure class="block flow-compact"><a href="#demo" class="aid-see block bg-black">voice alternative for background images</a></figure>
-</figure>


### PR DESCRIPTION
Sprites are not a best practice these days. These styles would be better provided more specifically by `.sprite` or `.icon` base classes. `user-select` seems useful for some use cases but not all. [Example.](https://codepen.io/ryanve/pen/KqwwwV)